### PR TITLE
Add Architecture Decision Records and ADR for Auth Topology

### DIFF
--- a/ProgressionLab.sln
+++ b/ProgressionLab.sln
@@ -53,6 +53,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "adr", "adr", "{7DD6913B-0EB0-41E6-9C05-353737F1D86C}"
 	ProjectSection(SolutionItems) = preProject
 		docs\adr\0001-auth-topology.md = docs\adr\0001-auth-topology.md
+		docs\adr\README.md = docs\adr\README.md
 	EndProjectSection
 EndProject
 Global

--- a/ProgressionLab.sln
+++ b/ProgressionLab.sln
@@ -47,9 +47,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProgressionLab.AspireTests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{9E57ABF4-6AE3-49BA-AB4D-D37F7E06E159}"
 	ProjectSection(SolutionItems) = preProject
-		docs\architecture-decisions\adr-001-dotnet-di-adoption.md = docs\architecture-decisions\adr-001-dotnet-di-adoption.md
-		docs\architecture-decisions\README.md = docs\architecture-decisions\README.md
 		docs\AI_GUIDELINES.md = docs\AI_GUIDELINES.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "adr", "adr", "{7DD6913B-0EB0-41E6-9C05-353737F1D86C}"
+	ProjectSection(SolutionItems) = preProject
+		docs\adr\0001-auth-topology.md = docs\adr\0001-auth-topology.md
 	EndProjectSection
 EndProject
 Global
@@ -197,6 +200,7 @@ Global
 		{08E69B3B-4418-40BD-80EC-B38C0ECFBAE2} = {106AE906-5075-410A-B941-912F811848EE}
 		{C7039CB5-4F76-4F19-ABD7-C755FAB2A870} = {106AE906-5075-410A-B941-912F811848EE}
 		{07D864BA-6245-D5C0-5C79-BB55D27ACBBF} = {B31B4797-1D9F-4288-808C-BE9A31A98C7D}
+		{7DD6913B-0EB0-41E6-9C05-353737F1D86C} = {9E57ABF4-6AE3-49BA-AB4D-D37F7E06E159}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0F19343-8185-4A9F-9165-0EA8544BC925}

--- a/docs/adr/0001-auth-topology.md
+++ b/docs/adr/0001-auth-topology.md
@@ -1,0 +1,65 @@
+﻿# ADR 0001 — Authentication & Authorization Topology
+
+- **Status:** Accepted
+- **Date:** 2025-08-14
+- **Owner:** ProgressionLab
+
+## Context
+We need secure user accounts and a future-proof way to authenticate users across:
+- a web experience (server-rendered/BFF),
+- a public API for first-party clients,
+- native iOS/Apple Watch apps.
+
+We want modern best practices (OIDC/OAuth2, PKCE, short-lived access tokens, refresh tokens), $0 local dev, and a clear path to scale or swap identity providers (e.g., Microsoft Entra).
+
+## Decision
+Adopt a **separate Identity Provider (IdP)** service using **OpenIddict + ASP.NET Identity**, with:
+- **Authorization Code + PKCE** flow for all interactive clients.
+- **Refresh tokens** (rotated, revoke-on-use).
+- **Scopes**: `api` (resource access), `offline_access` (refresh), `email`, `profile`.
+- **Claims/roles** for app-level authorization.
+- **API** validates tokens issued by the IdP and enforces `scope=api`.
+
+**Topology (initial deployment shape)**
+- `ProgressionLab.IdP` → OpenIddict server endpoints (`/connect/authorize`, `/connect/token`, `/connect/userinfo`, `/connect/logout`) and Identity UI (login/register/consent).
+- `ProgressionLab.Api` → resource server (JSON). Requires `[Authorize(Policy="ApiScope")]` where `ApiScope` = `scope contains "api"`.
+- `ProgressionLab.Web` (optional, staged later) → BFF: server-side session; tokens stay on server; browser only has an HTTP-only cookie.
+
+**Local dev:** All services in one solution; IdP on `https://localhost:<idp-port>`.  
+**Prod:** Independent deployables, e.g.:
+- IdP: `https://id.progressionlab.app`
+- API: `https://api.progressionlab.app`
+- Web: `https://app.progressionlab.app`
+
+## Rationale
+- **Security:** Standards-based flows; BFF keeps tokens out of the browser; short-lived access tokens plus rotated refresh tokens.
+- **Portability:** Clients and API depend only on OIDC metadata; we can federate to or replace with Entra later by changing `Authority`.
+- **Scalability:** IdP, API, and Web can scale/harden independently; clear trust boundaries.
+
+## Alternatives Considered
+- **JWT-only, app-issued tokens (no OIDC):** simpler, but harder to add native apps and external IdPs later; rework likely.
+- **Co-hosting IdP inside API:** fastest start, but couples concerns and complicates future split/federation.
+- **Hosted IdP (Auth0/Okta/Entra) from day 1:** quick, but adds cost and external dependency while we’re still iterating.
+
+## Consequences
+**Positive**
+- Clean separation of concerns; easy to add new clients (iOS, Watch).
+- Swap/federate IdPs later with minimal client changes.
+- Aligns with security best practices (PKCE, refresh rotation).
+
+**Negative / Trade-offs**
+- More initial wiring (Identity UI, consent, keys).
+- We own key rotation and email flows (dev: `smtp4dev`; prod: managed SMTP).
+
+## Operational Notes
+- **Tokens:** access 10–15 min; refresh 30–90 days; rotate + revoke on refresh.
+- **Scopes:** `api`, `offline_access`, `email`, `profile`.
+- **Claims/roles:** app roles for admin/privileged features.
+- **Keys:** dev signing/encryption certs locally; real certs + rotation before production.
+- **Security:** enforce email confirmation before issuing tokens; enable TOTP 2FA; log auth events; expose health checks.
+- **Discovery:** publish `/.well-known/openid-configuration` (OpenIddict does this).
+
+## Follow-ups
+- ADR-0002: Consent UX and scope grant strategy.
+- ADR-0003: Key management & token lifetime policy (dev vs prod).
+- ADR-0004: Web BFF pattern details and CSRF strategy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+﻿# Architecture Decision Records (ADRs)
+
+This index lists all Architecture Decision Records for the project.
+
+- ADR-0001 — Authentication & Authorization Topology: Adopt a separate Identity Provider (OpenIddict + ASP.NET Identity) with Authorization Code + PKCE, rotated refresh tokens, and API scope enforcement. See: [0001-auth-topology.md](./0001-auth-topology.md)


### PR DESCRIPTION
## What
- Added a README for Architecture Decision Records (ADRs).
- Created an ADR focused on Authentication & Authorization Topology.

## Why
- To formalize decision-making processes and document critical architectural choices.
- To provide clarity and reference regarding the authentication & authorization structure.

## How I tested
- N/A (Documentation changes, no functional code modified).

## Impact
**API:**
- [ ] New endpoint(s):
- [ ] Breaking changes:  
  **DB:**
- [ ] Migration(s):  
  **Security/Privacy:**
- [ ] Secrets, PII, auth changes  
  **Performance:**
- [ ] Hot paths, memory/allocs, latency notes  
  **Observability:**
- [ ] Logs, metrics, traces, health checks

## Risks & Rollback
- **Risk:** low
- **Rollback plan:** Revert PR via version control if necessary.

## Screenshots / Recording (optional)
- N/A

## Notes / Follow-ups
- Future ADRs should follow the structure introduced in the README for consistency.

---
### Checklist
- [ ] Builds & tests pass (`dotnet build`, `dotnet test`)
- [ ] CI is green
- [ ] Conventional commit title (feat/fix/chore/docs/refactor/test)
- [ ] Linked issue(s) (e.g., Closes #123)
- [ ] Tests added/updated (unit/integration) when appropriate
- [ ] Docs updated (README or `/docs`) if needed
- [ ] No secrets or licensed assets committed